### PR TITLE
feat: add input validation for search and deal ID parameters across t…

### DIFF
--- a/src/tools/getDeal.ts
+++ b/src/tools/getDeal.ts
@@ -10,6 +10,20 @@ export const registerGetDeal: ToolRegistration = (server, { dealsApi }) => {
       dealId: z.number().describe("Pipedrive deal ID"),
     },
     async ({ dealId }) => {
+      if (dealId === null || dealId === undefined || Number.isNaN(dealId)) {
+        const message = "dealId is required and must be a number";
+        logger.error(message);
+        return {
+          content: [
+            {
+              type: "text",
+              text: message,
+            },
+          ],
+          isError: true,
+        };
+      }
+
       try {
         // @ts-ignore - Bypass incorrect TypeScript definition, API expects just the ID
         const response = await dealsApi.getDeal(dealId);

--- a/src/tools/searchAll.ts
+++ b/src/tools/searchAll.ts
@@ -10,7 +10,10 @@ export const registerSearchAll: ToolRegistration = (
     "search-all",
     "Search across all item types (deals, persons, organizations, etc.)",
     {
-      term: z.string().describe("Search term"),
+      term: z
+        .string()
+        .min(2, "Search term must be at least 2 characters")
+        .describe("Search term"),
       itemTypes: z
         .string()
         .optional()
@@ -19,9 +22,25 @@ export const registerSearchAll: ToolRegistration = (
         ),
     },
     async ({ term, itemTypes }) => {
+      const trimmedTerm = term.trim();
+
+      if (trimmedTerm.length < 2) {
+        const message = "Search term must be at least 2 characters";
+        logger.error(message);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error performing search: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
       try {
         const response = await itemSearchApi.searchItem({
-          term,
+          term: trimmedTerm,
           item_types: itemTypes as any,
         });
         return {

--- a/src/tools/searchDeals.ts
+++ b/src/tools/searchDeals.ts
@@ -7,12 +7,31 @@ export const registerSearchDeals: ToolRegistration = (server, { dealsApi }) => {
     "search-deals",
     "Search deals by term",
     {
-      term: z.string().describe("Search term for deals"),
+      term: z
+        .string()
+        .min(2, "Search term must be at least 2 characters")
+        .describe("Search term for deals"),
     },
     async ({ term }) => {
+      const trimmedTerm = term.trim();
+
+      if (trimmedTerm.length < 2) {
+        const message = "Search term must be at least 2 characters";
+        logger.error(message);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error searching deals: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
       try {
         // @ts-ignore - Bypass incorrect TypeScript definition
-        const response = await dealsApi.searchDeals({ term });
+        const response = await dealsApi.searchDeals({ term: trimmedTerm });
         return {
           content: [
             {

--- a/src/tools/searchLeads.ts
+++ b/src/tools/searchLeads.ts
@@ -7,12 +7,31 @@ export const registerSearchLeads: ToolRegistration = (server, { leadsApi }) => {
     "search-leads",
     "Search leads by term",
     {
-      term: z.string().describe("Search term for leads"),
+      term: z
+        .string()
+        .min(2, "Search term must be at least 2 characters")
+        .describe("Search term for leads"),
     },
     async ({ term }) => {
+      const trimmedTerm = term.trim();
+
+      if (trimmedTerm.length < 2) {
+        const message = "Search term must be at least 2 characters";
+        logger.error(message);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error searching leads: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
       try {
         // @ts-ignore - Bypass incorrect TypeScript definition
-        const response = await leadsApi.searchLeads(term);
+        const response = await leadsApi.searchLeads(trimmedTerm);
         return {
           content: [
             {

--- a/src/tools/searchOrganizations.ts
+++ b/src/tools/searchOrganizations.ts
@@ -10,13 +10,32 @@ export const registerSearchOrganizations: ToolRegistration = (
     "search-organizations",
     "Search organizations by term",
     {
-      term: z.string().describe("Search term for organizations"),
+      term: z
+        .string()
+        .min(2, "Search term must be at least 2 characters")
+        .describe("Search term for organizations"),
     },
     async ({ term }) => {
+      const trimmedTerm = term.trim();
+
+      if (trimmedTerm.length < 2) {
+        const message = "Search term must be at least 2 characters";
+        logger.error(message);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error searching organizations: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
       try {
         // @ts-ignore - API method exists but TypeScript definition is wrong
         const response = await (organizationsApi as any).searchOrganization({
-          term,
+          term: trimmedTerm,
         });
         return {
           content: [

--- a/src/tools/searchPersons.ts
+++ b/src/tools/searchPersons.ts
@@ -10,12 +10,31 @@ export const registerSearchPersons: ToolRegistration = (
     "search-persons",
     "Search persons by term",
     {
-      term: z.string().describe("Search term for persons"),
+      term: z
+        .string()
+        .min(2, "Search term must be at least 2 characters")
+        .describe("Search term for persons"),
     },
     async ({ term }) => {
+      const trimmedTerm = term.trim();
+
+      if (trimmedTerm.length < 2) {
+        const message = "Search term must be at least 2 characters";
+        logger.error(message);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error searching persons: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
       try {
         // @ts-ignore - Bypass incorrect TypeScript definition
-        const response = await personsApi.searchPersons(term);
+        const response = await personsApi.searchPersons(trimmedTerm);
         return {
           content: [
             {

--- a/tests/tools/getDeal.test.ts
+++ b/tests/tools/getDeal.test.ts
@@ -177,6 +177,38 @@ describe("getDeal tool", () => {
     });
   });
 
+  describe("input validation", () => {
+    it("should return error when dealId is undefined", async () => {
+      const result = await registeredToolHandler({ dealId: undefined as any });
+
+      expect(mockDealsApi.getDeal).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "dealId is required and must be a number",
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should return error when dealId is null", async () => {
+      const result = await registeredToolHandler({ dealId: null as any });
+
+      expect(mockDealsApi.getDeal).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "dealId is required and must be a number",
+          },
+        ],
+        isError: true,
+      });
+    });
+  });
+
   describe("error handling", () => {
     it("should handle API errors with error message", async () => {
       // Arrange

--- a/tests/tools/searchAll.test.ts
+++ b/tests/tools/searchAll.test.ts
@@ -40,7 +40,7 @@ describe("searchAll tool", () => {
     const mockData = { id: 123, name: "Test Data" };
     (mockItemSearchApi.searchItem as Mock).mockResolvedValue({ data: mockData });
 
-    const result = await registeredToolHandler({ term: 123, itemTypes: "test" });
+    const result = await registeredToolHandler({ term: "Test", itemTypes: "test" });
 
     expect(result).toHaveProperty("content");
     expect((result as any).content[0]).toHaveProperty("type", "text");
@@ -49,8 +49,40 @@ describe("searchAll tool", () => {
   it("should handle API errors", async () => {
     (mockItemSearchApi.searchItem as Mock).mockRejectedValue(new Error("API error"));
 
-    const result = await registeredToolHandler({ term: 123, itemTypes: "test" });
+    const result = await registeredToolHandler({ term: "Test", itemTypes: "test" });
 
     expect((result as any).isError).toBe(true);
+  });
+
+  describe("input validation", () => {
+    it("should reject terms shorter than 2 characters", async () => {
+      const result = await registeredToolHandler({ term: "a", itemTypes: "deal" });
+
+      expect(mockItemSearchApi.searchItem).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Error performing search: Search term must be at least 2 characters",
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should trim whitespace before validation", async () => {
+      const result = await registeredToolHandler({ term: " a ", itemTypes: "deal" });
+
+      expect(mockItemSearchApi.searchItem).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Error performing search: Search term must be at least 2 characters",
+          },
+        ],
+        isError: true,
+      });
+    });
   });
 });

--- a/tests/tools/searchDeals.test.ts
+++ b/tests/tools/searchDeals.test.ts
@@ -99,6 +99,38 @@ describe("searchDeals tool", () => {
     });
   });
 
+  describe("input validation", () => {
+    it("should reject terms shorter than 2 characters", async () => {
+      const result = await registeredToolHandler({ term: "a" });
+
+      expect(mockDealsApi.searchDeals).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Error searching deals: Search term must be at least 2 characters",
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should trim whitespace before validation", async () => {
+      const result = await registeredToolHandler({ term: " a " });
+
+      expect(mockDealsApi.searchDeals).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Error searching deals: Search term must be at least 2 characters",
+          },
+        ],
+        isError: true,
+      });
+    });
+  });
+
   describe("error handling", () => {
     it("should handle API errors", async () => {
       (mockDealsApi.searchDeals as Mock).mockRejectedValue(

--- a/tests/tools/searchLeads.test.ts
+++ b/tests/tools/searchLeads.test.ts
@@ -40,7 +40,7 @@ describe("searchLeads tool", () => {
     const mockData = { id: 123, name: "Test Data" };
     (mockLeadsApi.searchLeads as Mock).mockResolvedValue({ data: mockData });
 
-    const result = await registeredToolHandler({ term: 123 });
+    const result = await registeredToolHandler({ term: "Test" });
 
     expect(result).toHaveProperty("content");
     expect((result as any).content[0]).toHaveProperty("type", "text");
@@ -49,8 +49,40 @@ describe("searchLeads tool", () => {
   it("should handle API errors", async () => {
     (mockLeadsApi.searchLeads as Mock).mockRejectedValue(new Error("API error"));
 
-    const result = await registeredToolHandler({ term: 123 });
+    const result = await registeredToolHandler({ term: "Test" });
 
     expect((result as any).isError).toBe(true);
+  });
+
+  describe("input validation", () => {
+    it("should reject terms shorter than 2 characters", async () => {
+      const result = await registeredToolHandler({ term: "a" });
+
+      expect(mockLeadsApi.searchLeads).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Error searching leads: Search term must be at least 2 characters",
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should trim whitespace before validation", async () => {
+      const result = await registeredToolHandler({ term: " a " });
+
+      expect(mockLeadsApi.searchLeads).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Error searching leads: Search term must be at least 2 characters",
+          },
+        ],
+        isError: true,
+      });
+    });
   });
 });

--- a/tests/tools/searchOrganizations.test.ts
+++ b/tests/tools/searchOrganizations.test.ts
@@ -40,7 +40,7 @@ describe("searchOrganizations tool", () => {
     const mockData = { id: 123, name: "Test Data" };
     (mockOrganizationsApi.searchOrganization as Mock).mockResolvedValue({ data: mockData });
 
-    const result = await registeredToolHandler({ term: 123 });
+    const result = await registeredToolHandler({ term: "Test" });
 
     expect(result).toHaveProperty("content");
     expect((result as any).content[0]).toHaveProperty("type", "text");
@@ -49,8 +49,40 @@ describe("searchOrganizations tool", () => {
   it("should handle API errors", async () => {
     (mockOrganizationsApi.searchOrganization as Mock).mockRejectedValue(new Error("API error"));
 
-    const result = await registeredToolHandler({ term: 123 });
+    const result = await registeredToolHandler({ term: "Test" });
 
     expect((result as any).isError).toBe(true);
+  });
+
+  describe("input validation", () => {
+    it("should reject terms shorter than 2 characters", async () => {
+      const result = await registeredToolHandler({ term: "a" });
+
+      expect(mockOrganizationsApi.searchOrganization).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Error searching organizations: Search term must be at least 2 characters",
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should trim whitespace before validation", async () => {
+      const result = await registeredToolHandler({ term: " a " });
+
+      expect(mockOrganizationsApi.searchOrganization).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Error searching organizations: Search term must be at least 2 characters",
+          },
+        ],
+        isError: true,
+      });
+    });
   });
 });

--- a/tests/tools/searchPersons.test.ts
+++ b/tests/tools/searchPersons.test.ts
@@ -109,6 +109,38 @@ describe("searchPersons tool", () => {
     });
   });
 
+  describe("input validation", () => {
+    it("should reject terms shorter than 2 characters", async () => {
+      const result = await registeredToolHandler({ term: "a" });
+
+      expect(mockPersonsApi.searchPersons).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Error searching persons: Search term must be at least 2 characters",
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should trim whitespace before validation", async () => {
+      const result = await registeredToolHandler({ term: " a " });
+
+      expect(mockPersonsApi.searchPersons).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Error searching persons: Search term must be at least 2 characters",
+          },
+        ],
+        isError: true,
+      });
+    });
+  });
+
   describe("error handling", () => {
     it("should handle API errors", async () => {
       (mockPersonsApi.searchPersons as Mock).mockRejectedValue(


### PR DESCRIPTION
This pull request adds robust input validation to all search and deal retrieval tools, ensuring that user input meets minimum requirements before making API calls. It also updates the corresponding tests to cover these validation scenarios, improving error handling and preventing unnecessary API usage.

**Input validation improvements:**

* All search tools (`searchDeals`, `searchLeads`, `searchOrganizations`, `searchPersons`, `searchAll`) now require the search term to be at least 2 characters long after trimming whitespace. If the input is invalid, a clear error message is returned and the API is not called. [[1]](diffhunk://#diff-fba10e895716fad6d17ea538ed12af534db9cd7329ce5278ac1580af8350b0feL10-R34) [[2]](diffhunk://#diff-f10518d8039136f35d500a50f01bce32672a7dc2a7fbc6607737f8fd70b1f9cdL10-R34) [[3]](diffhunk://#diff-22919a19ffabfc6cab846bac72787ed23804277b02c9739ec9864eb5f3ce0921L13-R38) [[4]](diffhunk://#diff-8f53de2582804b141a1984a9a3b8d6992e08fdc192136066cf991bbe7f36d68eL13-R37) [[5]](diffhunk://#diff-054e66f5ca64e0cc2202a5c7b82181d7b99286876c5f2553c0d1fd10eda1d5cbL13-R16) [[6]](diffhunk://#diff-054e66f5ca64e0cc2202a5c7b82181d7b99286876c5f2553c0d1fd10eda1d5cbR25-R43)
* The `getDeal` tool now checks that `dealId` is defined and a valid number before calling the API, returning an error message otherwise.

**Test enhancements:**

* Added new test cases for all tools to verify that invalid input (too short or whitespace-only search terms, or missing deal IDs) results in proper error handling and prevents API calls. [[1]](diffhunk://#diff-2578ee5335788b985271c32ba2e243982c3f6eaf8f4a72b9e75526a6a02cd171R180-R211) [[2]](diffhunk://#diff-985dbf807d7d90e84772be71f079b66972b2c39b62c97affa457c179a365492aL52-R87) [[3]](diffhunk://#diff-1ceb6aa68eb5d78a9c2b2c116f3df249395768475c778e5175e2d5b23e175ca8R102-R133) [[4]](diffhunk://#diff-1c4ada91ef15fc5b9d07a7095dee1be23ee03757bdfc92b142d6e29f097cf37aL52-R87) [[5]](diffhunk://#diff-b39026894cc58e59a9fce3c2038472440c5e6f8ffcd452fb9cf85a0c85b326c6L52-R87) [[6]](diffhunk://#diff-105755a64e30d64ae4ee5bd5822cdf6290c96de03cd673763d57f645628527a9R112-R143)
* Updated existing tests to use valid string search terms instead of numbers, aligning with the new input validation. [[1]](diffhunk://#diff-985dbf807d7d90e84772be71f079b66972b2c39b62c97affa457c179a365492aL43-R43) [[2]](diffhunk://#diff-1c4ada91ef15fc5b9d07a7095dee1be23ee03757bdfc92b142d6e29f097cf37aL43-R43) [[3]](diffhunk://#diff-b39026894cc58e59a9fce3c2038472440c5e6f8ffcd452fb9cf85a0c85b326c6L43-R43)

These changes make the tools more robust and user-friendly by catching input errors early and providing clear feedback.